### PR TITLE
Refactor SyncMonitor timer handling

### DIFF
--- a/RecoTool/Services/SyncMonitorService.cs
+++ b/RecoTool/Services/SyncMonitorService.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using System.Timers;
 using System.IO;
 using System.Collections.Concurrent;
+using OfflineFirstAccess.Helpers;
 
 namespace RecoTool.Services
 {
@@ -17,6 +18,7 @@ namespace RecoTool.Services
 
         private readonly object _gate = new object();
         private Timer _timer;
+        private ElapsedEventHandler _timerHandler;
         private Func<OfflineFirstService> _serviceProvider;
         private bool _lastLockActive;
         private bool _lastNetworkAvailable;
@@ -88,7 +90,8 @@ namespace RecoTool.Services
 
                 _timer = new Timer(PollInterval.TotalMilliseconds);
                 _timer.AutoReset = true;
-                _timer.Elapsed += OnTimerElapsed;
+                _timerHandler = async (_, e) => await OnTimerElapsed(e);
+                _timer.Elapsed += _timerHandler;
                 _timer.Start();
             }
         }
@@ -99,7 +102,11 @@ namespace RecoTool.Services
             {
                 if (_timer != null)
                 {
-                    _timer.Elapsed -= OnTimerElapsed;
+                    if (_timerHandler != null)
+                    {
+                        _timer.Elapsed -= _timerHandler;
+                        _timerHandler = null;
+                    }
                     _timer.Stop();
                     _timer.Dispose();
                     _timer = null;
@@ -107,7 +114,7 @@ namespace RecoTool.Services
             }
         }
 
-        private async void OnTimerElapsed(object sender, ElapsedEventArgs e)
+        private async Task OnTimerElapsed(ElapsedEventArgs e)
         {
             if (_isTickRunning) return;
             _isTickRunning = true;
@@ -118,7 +125,12 @@ namespace RecoTool.Services
 
                 // Check lock state
                 bool lockActive = false;
-                try { lockActive = await svc.IsGlobalLockActiveAsync(); } catch { lockActive = false; }
+                try { lockActive = await svc.IsGlobalLockActiveAsync(); }
+                catch (Exception ex)
+                {
+                    lockActive = false;
+                    LogManager.Warning("[SYNC-MONITOR] Unable to query global lock state", ex);
+                }
 
                 // Publish state change events
                 if (lockActive != _lastLockActive)
@@ -134,7 +146,12 @@ namespace RecoTool.Services
 
                 // Check network availability
                 bool networkAvailable = false;
-                try { networkAvailable = svc.IsNetworkSyncAvailable; } catch { networkAvailable = false; }
+                try { networkAvailable = svc.IsNetworkSyncAvailable; }
+                catch (Exception ex)
+                {
+                    networkAvailable = false;
+                    LogManager.Warning("[SYNC-MONITOR] Unable to query network availability", ex);
+                }
                 if (networkAvailable && !_lastNetworkAvailable)
                 {
                     _lastNetworkAvailable = true;
@@ -171,7 +188,10 @@ namespace RecoTool.Services
                         }
                     }
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    LogManager.Error("[SYNC-MONITOR] Periodic push failed", ex);
+                }
 
                 // Lightweight remote reconciliation DB change check (timestamp + length) every minute
                 try
@@ -187,8 +207,18 @@ namespace RecoTool.Services
                             {
                                 string remoteDir = null;
                                 string prefix = null;
-                                try { remoteDir = svc.GetParameter("CountryDatabaseDirectory"); } catch { remoteDir = null; }
-                                try { prefix = svc.GetParameter("CountryDatabasePrefix"); } catch { prefix = null; }
+                                try { remoteDir = svc.GetParameter("CountryDatabaseDirectory"); }
+                                catch (Exception ex)
+                                {
+                                    remoteDir = null;
+                                    LogManager.Warning("[SYNC-MONITOR] Failed to get CountryDatabaseDirectory", ex);
+                                }
+                                try { prefix = svc.GetParameter("CountryDatabasePrefix"); }
+                                catch (Exception ex)
+                                {
+                                    prefix = null;
+                                    LogManager.Warning("[SYNC-MONITOR] Failed to get CountryDatabasePrefix", ex);
+                                }
                                 if (string.IsNullOrWhiteSpace(prefix)) prefix = "DB_";
                                 if (!string.IsNullOrWhiteSpace(remoteDir))
                                 {
@@ -210,10 +240,16 @@ namespace RecoTool.Services
                         }
                     }
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    LogManager.Error("[SYNC-MONITOR] Remote reconciliation check failed", ex);
+                }
 
             }
-            catch { }
+            catch (Exception ex)
+            {
+                LogManager.Error("[SYNC-MONITOR] Timer tick failed", ex);
+            }
             finally
             {
                 _isTickRunning = false;


### PR DESCRIPTION
## Summary
- Use async Task-based timer tick and hook with async lambda
- Log exceptions instead of swallowing them in SyncMonitorService

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b391b9a6dc8324a06842e3f2758300