### PR TITLE
Refactor background sync handling and avoid blocking UI

### DIFF
--- a/RecoTool/RecoTool.csproj
+++ b/RecoTool/RecoTool.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Services\Enums\KPIType.cs" />
     <Compile Include="Services\OfflineFirstService.cs" />
     <Compile Include="Services\ReconciliationService.cs" />
+    <Compile Include="Services\BackgroundTaskQueue.cs" />
     <Compile Include="Services\UserFilterService.cs" />
     <Compile Include="Services\DTOs\ReconciliationViewData.cs" />
     <Compile Include="Services\TransformationService.cs" />

--- a/RecoTool/Services/BackgroundTaskQueue.cs
+++ b/RecoTool/Services/BackgroundTaskQueue.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using OfflineFirstAccess.Helpers;
+
+namespace RecoTool.Services
+{
+    /// <summary>
+    /// Simple singleton background task queue to serialize fire-and-forget operations.
+    /// </summary>
+    public sealed class BackgroundTaskQueue : IDisposable
+    {
+        private static readonly Lazy<BackgroundTaskQueue> _instance =
+            new Lazy<BackgroundTaskQueue>(() => new BackgroundTaskQueue());
+        public static BackgroundTaskQueue Instance => _instance.Value;
+
+        private readonly ConcurrentQueue<Func<Task>> _queue = new ConcurrentQueue<Func<Task>>();
+        private readonly SemaphoreSlim _signal = new SemaphoreSlim(0);
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private readonly Task _worker;
+
+        private BackgroundTaskQueue()
+        {
+            _worker = Task.Run(ProcessQueueAsync);
+        }
+
+        public void Enqueue(Func<Task> workItem)
+        {
+            if (workItem == null) throw new ArgumentNullException(nameof(workItem));
+            _queue.Enqueue(workItem);
+            _signal.Release();
+        }
+
+        private async Task ProcessQueueAsync()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                try
+                {
+                    await _signal.WaitAsync(_cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+
+                if (_queue.TryDequeue(out var work))
+                {
+                    try
+                    {
+                        await work().ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        try { LogManager.Error("[BG-QUEUE] Task failed", ex); } catch { }
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            try { _signal.Release(); } catch { }
+            try { _worker.Wait(TimeSpan.FromSeconds(1)); } catch { }
+            _signal.Dispose();
+            _cts.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add shared background task queue and use it for async sync/push operations
- parallelize pivot reconciliation creation and add ConfigureAwait(false) to library code
- copy Access files with async streams to avoid Task.Run blocking

## Testing
- `dotnet build RecoTool.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3967197f48324a7ca26f4c3e06438