### PR TITLE
Remove obsolete booking fields from reconciliation view

### DIFF
--- a/RecoTool/Services/DTOs/ReconciliationViewData.cs
+++ b/RecoTool/Services/DTOs/ReconciliationViewData.cs
@@ -124,7 +124,6 @@ namespace RecoTool.Services
         public string GUARANTEE_STATUS { get; set; }
 
         // DWINGS Guarantee extra fields (prefixed with G_ to avoid collisions)
-        public string G_BOOKING { get; set; }
         public string G_NATURE { get; set; }
         public string G_EVENT_STATUS { get; set; }
         public string G_EVENT_EFFECTIVEDATE { get; set; }
@@ -154,7 +153,6 @@ namespace RecoTool.Services
         public string G_NATUREOFDEAL { get; set; }
 
         // DWINGS Invoice extra fields (prefixed with I_)
-        public string I_BOOKING { get; set; }
         public string I_REQUESTED_INVOICE_AMOUNT { get; set; }
         public string I_SENDER_NAME { get; set; }
         public string I_RECEIVER_NAME { get; set; }

--- a/RecoTool/Windows/ReconciliationView.xaml
+++ b/RecoTool/Windows/ReconciliationView.xaml
@@ -994,7 +994,6 @@
                             </DataGridTextColumn>
                             
                             <!-- DWINGS Guarantee extended fields -->
-                            <DataGridTextColumn Header="G Booking" Binding="{Binding G_BOOKING}" Width="110"/>
                             <DataGridTextColumn Header="G Nature" Binding="{Binding G_NATURE}" Width="110"/>
                             <DataGridTextColumn Header="G Event Status" Binding="{Binding G_EVENT_STATUS}" Width="120"/>
                             <DataGridTextColumn Header="G Issue Date" Binding="{Binding G_ISSUEDATE}" Width="110"/>
@@ -1002,7 +1001,6 @@
                             <DataGridTextColumn Header="G Name" Binding="{Binding G_NAME1}" Width="160"/>
                             
                             <!-- DWINGS Invoice extended fields -->
-                            <DataGridTextColumn Header="I Booking" Binding="{Binding I_BOOKING}" Width="110"/>
                             <DataGridTextColumn Header="I Req Amount" Binding="{Binding I_REQUESTED_INVOICE_AMOUNT}" Width="130"/>
                             <DataGridTextColumn Header="I Curr" Binding="{Binding I_BILLING_CURRENCY}" Width="70"/>
                             <DataGridTextColumn Header="I Start" Binding="{Binding I_START_DATE}" Width="110"/>


### PR DESCRIPTION
## Summary
- drop unused G_BOOKING and I_BOOKING properties from reconciliation DTO
- remove G Booking and I Booking columns from reconciliation view

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dc2b23e08324b7ff85d438f2159c