### PR TITLE
Add G_GUARANTEE_TYPE property to reconciliation DTO

### DIFF
--- a/RecoTool/Services/DTOs/ReconciliationViewData.cs
+++ b/RecoTool/Services/DTOs/ReconciliationViewData.cs
@@ -152,6 +152,7 @@ namespace RecoTool.Services
         public string G_CONTROLER { get; set; }
         public string G_AUTOMATICBOOKOFF { get; set; }
         public string G_NATUREOFDEAL { get; set; }
+        public string G_GUARANTEE_TYPE { get; set; }
 
         // DWINGS Invoice extra fields (prefixed with I_)
         public string I_BOOKING { get; set; }


### PR DESCRIPTION
## Summary
- expose G_GUARANTEE_TYPE on ReconciliationViewData to surface DWINGS guarantee type

## Testing
- `dotnet build RecoTool.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dc72863c8324a994e3bad0fda454