### PR TITLE
Expose guarantee type data in reconciliation view

### DIFF
--- a/RecoTool/Services/DTOs/ReconciliationViewData.cs
+++ b/RecoTool/Services/DTOs/ReconciliationViewData.cs
@@ -122,6 +122,8 @@ namespace RecoTool.Services
         public decimal? GUARANTEE_AMOUNT { get; set; }
         public string GUARANTEE_CURRENCY { get; set; }
         public string GUARANTEE_STATUS { get; set; }
+        // DWINGS guarantee type (raw code)
+        public string GUARANTEE_TYPE { get; set; }
 
         // DWINGS Guarantee extra fields (prefixed with G_ to avoid collisions)
         public string G_BOOKING { get; set; }
@@ -152,6 +154,8 @@ namespace RecoTool.Services
         public string G_CONTROLER { get; set; }
         public string G_AUTOMATICBOOKOFF { get; set; }
         public string G_NATUREOFDEAL { get; set; }
+        // Guarantee type duplicated with G_ prefix to avoid collisions in bindings
+        public string G_GUARANTEE_TYPE { get; set; }
 
         // DWINGS Invoice extra fields (prefixed with I_)
         public string I_BOOKING { get; set; }

--- a/RecoTool/Windows/ReconciliationView.xaml
+++ b/RecoTool/Windows/ReconciliationView.xaml
@@ -987,7 +987,7 @@
                             <DataGridTextColumn Header="DW Syndicate" Binding="{Binding SYNDICATE}" Width="100"/>
                             <DataGridTextColumn Header="DW Currency" Binding="{Binding GUARANTEE_CURRENCY}" Width="80"/>
                             <DataGridTextColumn Header="DW Amount" Binding="{Binding GUARANTEE_AMOUNT, StringFormat={}{0:N2}}" Width="120"/>
-                            <DataGridTextColumn Header="Guarantee Type" Width="130" SortMemberPath="G_GUARANTEE_TYPE">
+                            <DataGridTextColumn Header="Guarantee Type" Width="130" SortMemberPath="GUARANTEE_TYPE">
                                 <DataGridTextColumn.Binding>
                                     <Binding Path="G_GUARANTEE_TYPE" Converter="{StaticResource GuaranteeTypeDisplayConverter}"/>
                                 </DataGridTextColumn.Binding>


### PR DESCRIPTION
## Summary
- add `GUARANTEE_TYPE` and `G_GUARANTEE_TYPE` to `ReconciliationViewData`
- sort Guarantee Type column using raw guarantee code

## Testing
- `dotnet build RecoTool/RecoTool.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dd07b06c83248f540886f7488d21