### PR TITLE
Specify invariant culture for date formatting

### DIFF
--- a/OfflineFirstAccess/Helpers/LogManager.cs
+++ b/OfflineFirstAccess/Helpers/LogManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Globalization;
 
 namespace OfflineFirstAccess.Helpers
 {
@@ -151,7 +152,7 @@ namespace OfflineFirstAccess.Helpers
         /// </summary>
         private static string FormatLogEntry(LogEntry entry)
         {
-            string baseMessage = $"{entry.Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{entry.Level,-7}] [Thread:{entry.ThreadId:D3}] {entry.Message}";
+            string baseMessage = $"{entry.Timestamp.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture)} [{entry.Level,-7}] [Thread:{entry.ThreadId:D3}] {entry.Message}";
 
             if (entry.Exception != null)
             {

--- a/RecoTool/Models/DataAmbre.cs
+++ b/RecoTool/Models/DataAmbre.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Windows.Markup;
 
 namespace RecoTool.Models
@@ -49,7 +50,7 @@ namespace RecoTool.Models
         /// </summary>
         public string GetUniqueKey()
         {
-            return $"{Event_Num}_{RawLabel}_{ReconciliationOrigin_Num}_{Operation_Date?.ToString("yyyyMMdd")}_{SignedAmount}";
+            return $"{Event_Num}_{RawLabel}_{ReconciliationOrigin_Num}_{Operation_Date?.ToString("yyyyMMdd", CultureInfo.InvariantCulture)}_{SignedAmount}";
         }
     }
 }

--- a/RecoTool/Services/OfflineFirstService.cs
+++ b/RecoTool/Services/OfflineFirstService.cs
@@ -4357,7 +4357,7 @@ namespace RecoTool.Services
                 if (!Directory.Exists(savedDir)) Directory.CreateDirectory(savedDir);
 
                 string baseName = Path.GetFileNameWithoutExtension(localDbPath);
-                string timeStamp = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss");
+                string timeStamp = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
                 string suffix = string.IsNullOrWhiteSpace(label) ? "PreImport" : label.Trim();
                 string backupPath = Path.Combine(savedDir, $"{baseName}_{suffix}_{timeStamp}.accdb");
 

--- a/RecoTool/Services/ReconciliationService.cs
+++ b/RecoTool/Services/ReconciliationService.cs
@@ -2112,10 +2112,10 @@ namespace RecoTool.Services
             string Norm(string s)
             {
                 if (string.IsNullOrWhiteSpace(s)) return s;
-                if (TryParseDwingsDate(s, out var dt)) return dt.ToString("yyyy-MM-dd");
-                if (DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out dt)) return dt.ToString("yyyy-MM-dd");
-                if (DateTime.TryParse(s, CultureInfo.GetCultureInfo("fr-FR"), DateTimeStyles.None, out dt)) return dt.ToString("yyyy-MM-dd");
-                if (DateTime.TryParse(s, CultureInfo.GetCultureInfo("it-IT"), DateTimeStyles.None, out dt)) return dt.ToString("yyyy-MM-dd");
+                if (TryParseDwingsDate(s, out var dt)) return dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                if (DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out dt)) return dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                if (DateTime.TryParse(s, CultureInfo.GetCultureInfo("fr-FR"), DateTimeStyles.None, out dt)) return dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+                if (DateTime.TryParse(s, CultureInfo.GetCultureInfo("it-IT"), DateTimeStyles.None, out dt)) return dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
                 return s;
             }
 

--- a/RecoTool/Windows/HomePage.xaml.cs
+++ b/RecoTool/Windows/HomePage.xaml.cs
@@ -15,6 +15,7 @@ using System.Reflection;
 using System.Windows.Media;
 using System.Text.Json;
 using System.Text;
+using System.Globalization;
 
 namespace RecoTool.Windows
 {
@@ -305,7 +306,7 @@ namespace RecoTool.Windows
                 for (int i = 0; i < dayCount; i++)
                 {
                     var day = minDay.AddDays(i);
-                    labels.Add(day.ToString("dd/MM"));
+                    labels.Add(day.ToString("dd/MM", CultureInfo.InvariantCulture));
                     int newCount = creations.Count(r => r.CreationDate.Value.Date == day);
                     int delCount = deletions.Count(r => r.DeleteDate.Value.Date == day);
                     newPerDay.Add(newCount);
@@ -502,7 +503,7 @@ namespace RecoTool.Windows
             _actionDistributionSeries = new SeriesCollection();
             _kpiRiskSeries = new SeriesCollection();
             _statusMessage = "Ready";
-            _lastUpdateTime = DateTime.Now.ToString("HH:mm:ss");
+            _lastUpdateTime = DateTime.Now.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
             
             // Initialiser les nouvelles propriétés de graphiques
             _receivableChartData = new ChartValues<double>();
@@ -880,7 +881,7 @@ namespace RecoTool.Windows
                 if (table == null || table.Rows.Count == 0)
                 {
                     _usingSnapshot = false;
-                    StatusMessage = $"No snapshot found for {date:dd/MM/yyyy}. Showing live data.";
+                    StatusMessage = $"No snapshot found for {date.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture)}. Showing live data.";
                     return false;
                 }
 
@@ -898,8 +899,8 @@ namespace RecoTool.Windows
                 ApplySnapshotCharts(row);
 
                 _usingSnapshot = true;
-                StatusMessage = $"Snapshot loaded for {date:dd/MM/yyyy}.";
-                LastUpdateTime = DateTime.Now.ToString("HH:mm:ss");
+                StatusMessage = $"Snapshot loaded for {date.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture)}.";
+                LastUpdateTime = DateTime.Now.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
                 return true;
             }
             catch (Exception ex)
@@ -1205,7 +1206,7 @@ namespace RecoTool.Windows
                     return;
                 }
 
-                string subject = $"Missing invoices report - {CurrentCountryName ?? "Unknown Country"} - {DateTime.Today:yyyy-MM-dd}";
+                string subject = $"Missing invoices report - {CurrentCountryName ?? "Unknown Country"} - {DateTime.Today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}";
 
                 var sb = new StringBuilder();
                 sb.Append("<html><body>");
@@ -1311,7 +1312,7 @@ namespace RecoTool.Windows
         private static string FormatCsvValue(object v)
         {
             if (v == null || v == DBNull.Value) return string.Empty;
-            if (v is DateTime dt) return dt.ToString("yyyy-MM-dd");
+            if (v is DateTime dt) return dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             return v.ToString();
         }
 
@@ -1642,7 +1643,7 @@ namespace RecoTool.Windows
                 AnalyzeAccountDistribution();
 
                 StatusMessage = $"Data loaded: {_reconciliationViewData.Count} rows";
-                LastUpdateTime = DateTime.Now.ToString("HH:mm:ss");
+                LastUpdateTime = DateTime.Now.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
 
                 System.Diagnostics.Debug.WriteLine($"Data loaded via ReconciliationService: {_reconciliationViewData.Count} rows for {_offlineFirstService.CurrentCountryId}");
             }
@@ -2245,7 +2246,7 @@ namespace RecoTool.Windows
             try
             {
                 UpdateTextBlock("CountryNameText", _offlineFirstService.CurrentCountryId ?? "N/A");
-                UpdateTextBlock("LastUpdateText", DateTime.Now.ToString("dd/MM/yyyy HH:mm"));
+                UpdateTextBlock("LastUpdateText", DateTime.Now.ToString("dd/MM/yyyy HH:mm", CultureInfo.InvariantCulture));
             }
             catch (Exception ex)
             {

--- a/RecoTool/Windows/ImportAmbreWindow.xaml.cs
+++ b/RecoTool/Windows/ImportAmbreWindow.xaml.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 using RecoTool.Models;
 using RecoTool.Services;
 using RecoTool.Helpers;
+using System.Globalization;
 
 namespace RecoTool.Windows
 {
@@ -154,7 +155,7 @@ namespace RecoTool.Windows
                     try
                     {
                         var fi = new FileInfo(_selectedFilePath1);
-                        FileInfoText1.Text = $"File: {fi.Name} ({fi.Length / 1024:N0} KB) - Modified: {fi.LastWriteTime:dd/MM/yyyy HH:mm}";
+                        FileInfoText1.Text = $"File: {fi.Name} ({(fi.Length / 1024).ToString("N0", CultureInfo.InvariantCulture)} KB) - Modified: {fi.LastWriteTime.ToString("dd/MM/yyyy HH:mm", CultureInfo.InvariantCulture)}";
                     }
                     catch { FileInfoText1.Text = string.Empty; }
 
@@ -189,7 +190,7 @@ namespace RecoTool.Windows
                     try
                     {
                         var fi = new FileInfo(_selectedFilePath2);
-                        FileInfoText2.Text = $"File: {fi.Name} ({fi.Length / 1024:N0} KB) - Modified: {fi.LastWriteTime:dd/MM/yyyy HH:mm}";
+                        FileInfoText2.Text = $"File: {fi.Name} ({(fi.Length / 1024).ToString("N0", CultureInfo.InvariantCulture)} KB) - Modified: {fi.LastWriteTime.ToString("dd/MM/yyyy HH:mm", CultureInfo.InvariantCulture)}";
                     }
                     catch { FileInfoText2.Text = string.Empty; }
 
@@ -778,7 +779,7 @@ namespace RecoTool.Windows
         {
             Dispatcher.Invoke(() =>
             {
-                var timestamp = DateTime.Now.ToString("HH:mm:ss");
+                var timestamp = DateTime.Now.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
                 var prefix = isError ? "[ERREUR]" : "[INFO]";
                 var logEntry = $"{timestamp} {prefix} {message}\n";
                 

--- a/RecoTool/Windows/ReconciliationDetailWindow.xaml.cs
+++ b/RecoTool/Windows/ReconciliationDetailWindow.xaml.cs
@@ -145,7 +145,7 @@ namespace RecoTool.UI.Views.Windows
         {
             if (_item == null) return;
 
-            OperationDateValue.Text = _item.Operation_Date?.ToString("yyyy-MM-dd") ?? "";
+            OperationDateValue.Text = _item.Operation_Date?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "";
             DescriptionValue.Text = _item.RawLabel ?? "";
             AmountValue.Text = _item.SignedAmount.ToString("N2", CultureInfo.InvariantCulture);
             CurrencyValue.Text = _item.CCY ?? "";
@@ -169,7 +169,7 @@ namespace RecoTool.UI.Views.Windows
                 : string.Empty;
 
             FXRateValue.Text = string.Empty; // Unknown without FX data
-            ValueDateValue.Text = _item.Value_Date?.ToString("yyyy-MM-dd") ?? "";
+            ValueDateValue.Text = _item.Value_Date?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) ?? "";
             TransactionTypeValue.Text = !string.IsNullOrWhiteSpace(_item.Pivot_TransactionCodesFromLabel)
                 ? _item.Pivot_TransactionCodesFromLabel
                 : _item.Pivot_TRNFromLabel;

--- a/RecoTool/Windows/ReconciliationImportWindow.xaml.cs
+++ b/RecoTool/Windows/ReconciliationImportWindow.xaml.cs
@@ -14,6 +14,7 @@ using RecoTool.Models;
 using OfflineFirstAccess.Data;
 using OfflineFirstAccess.Models;
 using System.Data.OleDb;
+using System.Globalization;
 
 namespace RecoTool.Windows
 {
@@ -163,7 +164,7 @@ namespace RecoTool.Windows
             try
             {
                 var fi = new FileInfo(path);
-                target.Text = $"File: {fi.Name} ({fi.Length / 1024:N0} KB) - Modified: {fi.LastWriteTime:dd/MM/yyyy HH:mm}";
+                target.Text = $"File: {fi.Name} ({(fi.Length / 1024).ToString("N0", CultureInfo.InvariantCulture)} KB) - Modified: {fi.LastWriteTime.ToString("dd/MM/yyyy HH:mm", CultureInfo.InvariantCulture)}";
             }
             catch
             {
@@ -324,9 +325,9 @@ namespace RecoTool.Windows
                     try
                     {
                         if (v == null) return null;
-                        if (v is DateTime dt) return dt.ToString("dd/MM/yyyy");
-                        if (v is double d) return DateTime.FromOADate(d).ToString("dd/MM/yyyy");
-                        if (DateTime.TryParse(v.ToString(), out var parsed)) return parsed.ToString("dd/MM/yyyy");
+                        if (v is DateTime dt) return dt.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture);
+                        if (v is double d) return DateTime.FromOADate(d).ToString("dd/MM/yyyy", CultureInfo.InvariantCulture);
+                        if (DateTime.TryParse(v.ToString(), out var parsed)) return parsed.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture);
                     }
                     catch { }
                     return null;
@@ -845,7 +846,7 @@ namespace RecoTool.Windows
         {
             Dispatcher.Invoke(() =>
             {
-                var timestamp = DateTime.Now.ToString("HH:mm:ss");
+                var timestamp = DateTime.Now.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
                 var prefix = isError ? "[ERROR]" : "[INFO]";
                 ImportLogText.Text += $"{timestamp} {prefix} {message}\n";
                 LogScrollViewer.ScrollToEnd();

--- a/RecoTool/Windows/ReconciliationView.xaml.cs
+++ b/RecoTool/Windows/ReconciliationView.xaml.cs
@@ -1989,7 +1989,7 @@ namespace RecoTool.Windows
 
                 // Basic formatting similar to grid
                 if (raw is DateTime dt)
-                    return dt.ToString("yyyy-MM-dd");
+                    return dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
                 if (raw is bool bval)
                     return bval ? "True" : "False";
                 if (raw is decimal dec)
@@ -2905,7 +2905,7 @@ namespace RecoTool.Windows
                 var dir = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "RecoTool");
                 if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
                 var path = System.IO.Path.Combine(dir, "actions.log");
-                var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss}\t{user}\t{action}\t{details}";
+                var line = $"{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)}\t{user}\t{action}\t{details}";
                 System.IO.File.AppendAllLines(path, new[] { line }, Encoding.UTF8);
             }
             catch
@@ -2922,7 +2922,7 @@ namespace RecoTool.Windows
                 var dir = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "RecoTool");
                 if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
                 var path = System.IO.Path.Combine(dir, "perf.log");
-                var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss}\t{area}\t{details}";
+                var line = $"{DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)}\t{area}\t{details}";
                 System.IO.File.AppendAllLines(path, new[] { line }, Encoding.UTF8);
             }
             catch { }
@@ -2932,7 +2932,7 @@ namespace RecoTool.Windows
         private string GenerateWhereClause()
         {
             string Esc(string s) => string.IsNullOrEmpty(s) ? s : s.Replace("'", "''");
-            string DateLit(DateTime d) => "#" + d.ToString("yyyy-MM-dd") + "#"; // Access date literal
+            string DateLit(DateTime d) => "#" + d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) + "#"; // Access date literal
             string MapUiToDb(string s)
             {
                 switch ((s ?? string.Empty).Trim().ToUpperInvariant())

--- a/RecoTool/Windows/ReportsWindow.xaml.cs
+++ b/RecoTool/Windows/ReportsWindow.xaml.cs
@@ -16,6 +16,7 @@ using RecoTool.Services;
 using System.Threading;
 using Excel = Microsoft.Office.Interop.Excel;
 using System.Runtime.InteropServices;
+using System.Globalization;
 
 namespace RecoTool.Windows
 {
@@ -417,7 +418,7 @@ namespace RecoTool.Windows
             await Task.Delay(2000);
 
             // Écriture basique d'un fichier de test
-            var content = $"Report {reportType}\nCountry: {CurrentCountry?.CNT_Name}\nPeriod: {StartDate:dd/MM/yyyy} - {EndDate:dd/MM/yyyy}\nNumber of rows: {data.Count}\nGenerated on: {DateTime.Now}";
+            var content = $"Report {reportType}\nCountry: {CurrentCountry?.CNT_Name}\nPeriod: {StartDate.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture)} - {EndDate.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture)}\nNumber of rows: {data.Count}\nGenerated on: {DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)}";
             File.WriteAllText(filePath.Replace(".xlsx", ".txt"), content);
         }
 
@@ -446,7 +447,7 @@ namespace RecoTool.Windows
             await Task.Delay(1500);
 
             // Écriture basique d'un fichier de test
-            var content = $"Export {exportType}\nCountry: {CurrentCountry?.CNT_Name}\nPeriod: {StartDate:dd/MM/yyyy} - {EndDate:dd/MM/yyyy}\nNumber of rows: {data.Count}\nExported on: {DateTime.Now}";
+            var content = $"Export {exportType}\nCountry: {CurrentCountry?.CNT_Name}\nPeriod: {StartDate.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture)} - {EndDate.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture)}\nNumber of rows: {data.Count}\nExported on: {DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)}";
             File.WriteAllText(filePath.Replace(".xlsx", ".txt").Replace(".csv", ".txt"), content);
         }
 


### PR DESCRIPTION
## Summary
- enforce invariant date formatting across home page, import windows, log helpers, and report generators
- add missing System.Globalization directives for consistent culture-free serialization

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a53de18c8324a093523e3f8f3cfd